### PR TITLE
add a hook for additional custom Lux initialization

### DIFF
--- a/api/js/examples/index.js
+++ b/api/js/examples/index.js
@@ -185,5 +185,5 @@ $().ready(function () {
         }
     }));
 
-    if (view_schema.extra_lux_init) view_schema.extra_lux_init();
+    if (view_schema.on_load) view_schema.on_load();
 });


### PR DESCRIPTION
This allows `view_schema` to add Lux items to the scene easily.
